### PR TITLE
Fix category name itests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .tox/
 .cache/
 virtualenv_run/
+.pytest_cache/

--- a/tests/eyny_clientlib_test.py
+++ b/tests/eyny_clientlib_test.py
@@ -36,7 +36,8 @@ class TestEynyForum(object):
     def test_list_filters(Self, forum):
         result = forum.list_filters()
         assert len(result['categories']) > 0
-        assert u'電影' in [cat['name'] for cat in result['categories']]
+        categories = [cat['name'] for cat in result['categories']]
+        assert "Other" in categories
         assert len(result['mod']) > 0
 
     @pytest.mark.parametrize('search_string', (


### PR DESCRIPTION
I can't fix the skipped tests that require login because eyny won't let it register with any of my email addresses :(