### PR TITLE
Fix video playback seek problem

### DIFF
--- a/src/plugin.video.eyny/addon.py
+++ b/src/plugin.video.eyny/addon.py
@@ -332,10 +332,7 @@ class EynyGui(object):
                 return
             return self.play_video(vid, play_info['sizes'][ret])
 
-        play_item = xbmcgui.ListItem(
-            path=self.build_request_url(
-                play_info['video'],
-                play_info['current_url']))
+        play_item = xbmcgui.ListItem(path=play_info['video'])
         play_item.setProperty("IsPlayable", "true")
         play_item.setInfo(
             type="Video",


### PR DESCRIPTION
Use `play_info['video']` directly to avoid `Range` in headers gets overridden in `build_request_url`